### PR TITLE
removed space in branch value for Cargo.toml

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -7,7 +7,7 @@
 ```
 [dependencies]
 tree-sitter = "0.19"
-tree-sitter-jinja2 = { git = "ssh://git@github.com/dbt-labs/tree-sitter-jinja2", branch =" main" }
+tree-sitter-jinja2 = { git = "ssh://git@github.com/dbt-labs/tree-sitter-jinja2", branch = "main" }
 ```
 
 ```rust


### PR DESCRIPTION
Little space in `branch` value caused error while trying to include this repository as dependency.
Error:
```
Caused by
  failed to load source for dependency `tree-sitter-jinja2`
Caused by
  Unable to update ssh://git@github.com/dbt-labs/tree-sitter-jinja2?branch= main
Caused by
  '+refs/heads/ main:refs/remotes/origin/ main' is not a valid refspec.; class=Invalid (3)

```

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/tree-sitter-jinja2/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
